### PR TITLE
fix mixed content error when using the unofficial download links

### DIFF
--- a/pages/BSP_Viewer-Download.html
+++ b/pages/BSP_Viewer-Download.html
@@ -62,9 +62,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/bspviewer156.exe">Installer
+                  <li><a href="https://nemstools.github.io/files/bspviewer156.exe">Installer
                       (733 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/bspviewer156.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/bspviewer156.zip">Archive
                       (540 KB)</a></li>
                 </ul>
 

--- a/pages/Batch_Compiler-Download.html
+++ b/pages/Batch_Compiler-Download.html
@@ -62,9 +62,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/batchcompiler312.exe">Installer
+                  <li><a href="https://nemstools.github.io/files/batchcompiler312.exe">Installer
                       (365 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/batchcompiler312.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/batchcompiler312.zip">Archive
                       (139 KB)</a></li>
                 </ul>
 
@@ -92,7 +92,7 @@
                       Site</a> / <a
                       href="https://web.archive.org/web/20191028073653/http://halflife.bluefang-logic.com/file.htm?act=view&amp;id=1">
                       Web Archive mirror</a></li>
-                  <li><a href="http://nemstools.github.io/files/HL-Compiled1.4.exe">Download from Github mirror</a></li>
+                  <li><a href="https://nemstools.github.io/files/HL-Compiled1.4.exe">Download from Github mirror</a></li>
 
                 </ul>
               </div>
@@ -134,7 +134,7 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/mappingtools.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/mappingtools.zip">Archive
                       (1,646 KB)</a></li>
                 </ul>
               </div>

--- a/pages/Crafty-Download.html
+++ b/pages/Crafty-Download.html
@@ -62,9 +62,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/crafty102.exe">Installer
+                  <li><a href="https://nemstools.github.io/files/crafty102.exe">Installer
                       (3,319 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/crafty102.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/crafty102.zip">Archive
                       (4,338 KB)</a></li>
                 </ul>
 

--- a/pages/GCFScape-Download.html
+++ b/pages/GCFScape-Download.html
@@ -62,9 +62,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/gcfscape186.exe">Installer
+                  <li><a href="https://nemstools.github.io/files/gcfscape186.exe">Installer
                       (525 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/gcfscape186.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/gcfscape186.zip">Archive
                       (334 KB)</a></li>
                 </ul>
 

--- a/pages/MAP_Viewer-Download.html
+++ b/pages/MAP_Viewer-Download.html
@@ -59,7 +59,7 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/mapviewer101.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/mapviewer101.zip">Archive
                       (74 KB)</a></li>
                 </ul>
 
@@ -103,7 +103,7 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/mapviewersource101.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/mapviewersource101.zip">Archive
                       (74 KB)</a></li>
                 </ul>
               </div>

--- a/pages/Miscellaneous-Auto_Seamer.html
+++ b/pages/Miscellaneous-Auto_Seamer.html
@@ -66,7 +66,7 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/autoseamer101.zip">Auto
+                  <li><a href="https://nemstools.github.io/files/autoseamer101.zip">Auto
                       Seamer v1.0.1</a></li>
                 </ul>
 

--- a/pages/Miscellaneous-BSP_View.html
+++ b/pages/Miscellaneous-BSP_View.html
@@ -76,9 +76,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/bspview110.zip">BSP
+                  <li><a href="https://nemstools.github.io/files/bspview110.zip">BSP
                       View v1.1.0</a></li>
-                  <li><a href="http://nemstools.github.io/files/bsptool110source.zip">BSP
+                  <li><a href="https://nemstools.github.io/files/bsptool110source.zip">BSP
                       View v1.1.0 Source</a></li>
                 </ul>
 

--- a/pages/Miscellaneous-HLLib.html
+++ b/pages/Miscellaneous-HLLib.html
@@ -75,9 +75,9 @@
                 <b>Download from unofficial Github mirror:</b>
 
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/hllib246.zip">HLLib
+                  <li><a href="https://nemstools.github.io/files/hllib246.zip">HLLib
                       v2.4.6 Archive (411 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/hllib118.zip">HLLib
+                  <li><a href="https://nemstools.github.io/files/hllib118.zip">HLLib
                       v1.1.8 Archive (186 KB)</a></li>
                 </ul>
 

--- a/pages/Miscellaneous-Open_Now.html
+++ b/pages/Miscellaneous-Open_Now.html
@@ -92,11 +92,11 @@
                 <b>Download from unofficial Github mirror:</b>
 
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/opennow110.exe">Open
+                  <li><a href="https://nemstools.github.io/files/opennow110.exe">Open
                       Now! v1.1.0 Installer (450 KB)</a>*</li>
-                  <li><a href="http://nemstools.github.io/files/opennow110.zip">Open
+                  <li><a href="https://nemstools.github.io/files/opennow110.zip">Open
                       Now! v1.1.0 Archive (65 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/opennow110-source.zip">Open
+                  <li><a href="https://nemstools.github.io/files/opennow110-source.zip">Open
                       Now! v1.1.0 Source Code (105 KB)</a></li>
                 </ul>
 

--- a/pages/Miscellaneous-PDN_VTF_Plug-In.html
+++ b/pages/Miscellaneous-PDN_VTF_Plug-In.html
@@ -77,9 +77,9 @@
                 <b>Download from unofficial Github mirror:</b>
 
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/pdnvtfplugin111.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/pdnvtfplugin111.zip">Archive
                       (536 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/pdnvtfplugin111-source.zip">Source
+                  <li><a href="https://nemstools.github.io/files/pdnvtfplugin111-source.zip">Source
                       Code (537 KB)</a></li>
                 </ul>
 

--- a/pages/Miscellaneous-PS_VTF_Plug-In.html
+++ b/pages/Miscellaneous-PS_VTF_Plug-In.html
@@ -75,7 +75,7 @@
                 <b>Download from unofficial Github mirror:</b>
 
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/psvtfplugin1011.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/psvtfplugin1011.zip">Archive
                       (257 KB)</a></li>
                 </ul>
 

--- a/pages/Miscellaneous-wad2bmp.html
+++ b/pages/Miscellaneous-wad2bmp.html
@@ -75,7 +75,7 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/wad2bmp201.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/wad2bmp201.zip">Archive
                       (69 KB)</a></li>
                 </ul>
 

--- a/pages/Terrain_Generator-Download.html
+++ b/pages/Terrain_Generator-Download.html
@@ -62,9 +62,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/terraingenerator305.exe">Installer
+                  <li><a href="https://nemstools.github.io/files/terraingenerator305.exe">Installer
                       (523 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/terraingenerator305.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/terraingenerator305.zip">Archive
                       (301 KB)</a></li>
                 </ul>
 

--- a/pages/VTFLib-Download.html
+++ b/pages/VTFLib-Download.html
@@ -62,9 +62,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/vtfedit133.exe">Installer
+                  <li><a href="https://nemstools.github.io/files/vtfedit133.exe">Installer
                       (2,112 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/vtfedit133.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/vtfedit133.zip">Archive
                       (2,383 KB)</a></li>
                 </ul>
 
@@ -167,9 +167,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/vtflib132.zip">Source
+                  <li><a href="https://nemstools.github.io/files/vtflib132.zip">Source
                       Code Archive (2,761 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/vtflib132-bin.zip">Binary
+                  <li><a href="https://nemstools.github.io/files/vtflib132-bin.zip">Binary
                       Archive (2,507 KB)</a></li>
                 </ul>
               </div>

--- a/pages/virtuAMP-Download.html
+++ b/pages/virtuAMP-Download.html
@@ -62,9 +62,9 @@
 
                 <b>Download from unofficial Github mirror:</b>
                 <ul>
-                  <li><a href="http://nemstools.github.io/files/virtuamp121.exe">Installer
+                  <li><a href="https://nemstools.github.io/files/virtuamp121.exe">Installer
                       (807 KB)</a></li>
-                  <li><a href="http://nemstools.github.io/files/virtuamp121.zip">Archive
+                  <li><a href="https://nemstools.github.io/files/virtuamp121.zip">Archive
                       (752 KB)</a></li>
                 </ul>
               </div>


### PR DESCRIPTION
When my mates and I were trying to get GCFScape, we came upon a weird issue due to how the site was made. Chromium gets very angry that the site is HTTPS, but the download gets redirected from HTTP -> HTTPS
![image](https://user-images.githubusercontent.com/2979691/133925486-5e6e2f5f-733f-4195-b979-beeb4d482b68.png)

Since the site itself has HTTPS, the files can be served over HTTPS directly without issue; this can be confirmed by using browser devtools to edit the links on the pages directly.

I've updated the download pages to fix this.